### PR TITLE
some pride map updates

### DIFF
--- a/visualizations/pride_map
+++ b/visualizations/pride_map
@@ -5,54 +5,30 @@ style:
     - type: symbol
       filter:
         - any
-        - [ ==, [ get, 'lgbtq' ], only ]
-      layout:
-        icon-image: https://raw.githubusercontent.com/Lumikeiju/openstreetmap/main/resources/icons/lgbtq/osmheart_lgbtq_horizontal_128.png
-        icon-allow-overlap: true
-        icon-anchor: bottom
-        icon-offset: [0, -24]
-        icon-size: 0.25
-        text-field: '{name}'
-        text-font: [Noto Sans Regular]
-        text-anchor: center
-        text-optional: true
-        text-justify: auto
-        text-radial-offset: 0
-
-    - type: symbol
-      filter:
-        - any
-        - [ ==, [ get, 'lgbtq' ], primary ]
-      layout:
-        icon-image: https://raw.githubusercontent.com/Lumikeiju/openstreetmap/main/resources/icons/lgbtq/osmheart_lgbtq_slanted_128.png
-        icon-allow-overlap: true
-        icon-anchor: bottom
-        icon-offset: [0, -24]
-        icon-size: 0.25
-        text-field: '{name}'
-        text-font: [Noto Sans Regular]
-        text-anchor: center
-        text-optional: true
-        text-justify: auto
-        text-radial-offset: 0
-
-    - type: symbol
-      filter:
-        - any
-        - [ ==, [ get, 'lgbtq' ], welcome ]
-      layout:
-        icon-image: https://raw.githubusercontent.com/Lumikeiju/openstreetmap/main/resources/icons/lgbtq/osmpin_lgbtq_slanted_128.png
-        icon-allow-overlap: true
-        icon-anchor: bottom
-        icon-offset: [0, -24]
-        icon-size: 0.25
-        text-field: '{name}'
-        text-font: [Noto Sans Regular]
-        text-anchor: center
-        text-optional: true
-        text-justify: auto
-        text-radial-offset: 0
+        - [ ==, [ get, lgbtq ], only ]
+        - [ ==, [ get, lgbtq ], welcome ]
+        - [ ==, [ get, lgbtq ], primary ]
+      icon-image:
+        - match
+        - [get, lgbtq]
+        - welcome
+        - https://raw.githubusercontent.com/Lumikeiju/openstreetmap/main/resources/icons/lgbtq/osmpin_lgbtq_slanted_128.png
+        - only
+        - https://raw.githubusercontent.com/Lumikeiju/openstreetmap/main/resources/icons/lgbtq/osmheart_lgbtq_horizontal_128.png
+        - https://raw.githubusercontent.com/Lumikeiju/openstreetmap/main/resources/icons/lgbtq/osmheart_lgbtq_slanted_128.png
+      icon-allow-overlap: true
+      icon-anchor: bottom
+      icon-size: 0.25
+      text-field: '{name}'
+      text-anchor: top
+      text-optional: true
+      text-halo-width: 2
+      text-halo-color: white
 ---
-[out:xml][timeout:300];
-nwr["lgbtq"~"only|primary|welcome"]({{bbox}});
-(._;>;); out meta;
+//[bbox:{{bbox}}][out:xml][timeout:300];
+(
+  nwr[lgbtq=only];
+  nwr[lgbtq=primary];
+  nwr[lgbtq=welcome];
+);
+out center meta;

--- a/visualizations/pride_map
+++ b/visualizations/pride_map
@@ -25,7 +25,7 @@ style:
       text-halo-width: 2
       text-halo-color: white
 ---
-//[bbox:{{bbox}}][out:xml][timeout:300];
+[bbox:{{bbox}}][out:xml][timeout:300];
 (
   nwr[lgbtq=only];
   nwr[lgbtq=primary];


### PR DESCRIPTION
Hi Amy 👋 

Love the Ultra-powered Pride Map. I also experimented with making an LGBTQ Ultra map after seeing the LGBTQ+Map using the [recent emoji support](https://overpass-ultra.us/docs/Examples/emoji/) but these pins/hearts are way better!!

here's a tweaked query with a a few improvements:

* 1 layer with a `match` expression for `icon-image`
* moved `layout` keys out of `layout` key ([Ultra auto-sorts `paint` and `layout` keys for you](https://overpass-ultra.us/docs/style/#automatic-paint-and-layer-keys))
* added a white halo to the text
* simplified positioning of text & image
* updated the overpass query to look for the various values of `lgbtq` separately rather than using a regex (regexes are slow, and for something like matching 3 known values, doing it this way makes for a faster query)


Tangent: you could include links in the readme that load your query from the repo, eg: https://overpass-ultra.us/#query=url:https://raw.githubusercontent.com/Lumikeiju/openstreetmap/main/visualizations/pride_map